### PR TITLE
Broadcast user creation

### DIFF
--- a/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
+++ b/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
@@ -1,5 +1,6 @@
 defmodule ChatServer.GetSocketUser do
   alias ChatServer.Auth
+  alias ChatServer.BroadcastEvent
   alias ChatServer.Schema
 
   def call(%{"token" => token}) do
@@ -32,10 +33,15 @@ defmodule ChatServer.GetSocketUser do
   defp create_user(params) do
     case Schema.User.create(params) do
       {:ok, user} ->
-        ChatPubSub.broadcast("users", "user:created", user)
+        broadcast_event(user)
         {:ok, user}
       _ ->
         {:error, "Error creating user"}
     end
+  end
+
+  defp broadcast_event(user) do
+    BroadcastEvent.call("user:created", user)
+    ChatPubSub.broadcast("users", "user:created", user)
   end
 end

--- a/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
+++ b/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
@@ -1,17 +1,28 @@
 defmodule ChatServer.GetSocketUser do
+  alias ChatServer.Auth
   alias ChatServer.Schema
 
-  def call(type, params) when is_atom(type) do
+  def call(%{"token" => token}) do
+    case Auth.get_user(token) do
+      {:ok, auth_user} -> get_or_create_by(:user, auth_user)
+      _ -> :error
+    end
+  end
+  def call(%{"type" => "guest"} = params) do
+    get_or_create_by(:guest, params)
+  end
+
+  defp get_or_create_by(type, params) do
     type
     |> filtered_params(params)
-    |> get_or_create_by
+    |> get_or_create_record
   end
 
   defp filtered_params(type, params) do
     Schema.User.filter_params(type, params)
   end
 
-  defp get_or_create_by(params) do
+  defp get_or_create_record(params) do
     case Schema.User.get_by(params) do
       nil -> create_user(params)
       user -> {:ok, user}
@@ -24,7 +35,7 @@ defmodule ChatServer.GetSocketUser do
         ChatPubSub.broadcast("users", "user:created", user)
         {:ok, user}
       _ ->
-        {:error, "Error creating user."}
+        {:error, "Error creating user"}
     end
   end
 end

--- a/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
+++ b/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
@@ -1,0 +1,30 @@
+defmodule ChatServer.GetSocketUser do
+  alias ChatServer.Schema
+
+  def call(type, params) when is_atom(type) do
+    type
+    |> filtered_params(params)
+    |> get_or_create_by
+  end
+
+  defp filtered_params(type, params) do
+    Schema.User.filter_params(type, params)
+  end
+
+  defp get_or_create_by(params) do
+    case Schema.User.get_by(params) do
+      nil -> create_user(params)
+      user -> {:ok, user}
+    end
+  end
+
+  defp create_user(params) do
+    case Schema.User.create(params) do
+      {:ok, user} ->
+        ChatPubSub.broadcast("users", "user:created", user)
+        {:ok, user}
+      _ ->
+        {:error, "Error creating user."}
+    end
+  end
+end

--- a/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
+++ b/apps/chat_server/lib/chat_server/contexts/users/get_socket_user.ex
@@ -34,7 +34,7 @@ defmodule ChatServer.GetSocketUser do
     case Schema.User.create(params) do
       {:ok, user} ->
         broadcast_event(user)
-        {:ok, user}
+        {:created, user}
       _ ->
         {:error, "Error creating user"}
     end
@@ -42,6 +42,5 @@ defmodule ChatServer.GetSocketUser do
 
   defp broadcast_event(user) do
     BroadcastEvent.call("user:created", user)
-    ChatPubSub.broadcast("users", "user:created", user)
   end
 end

--- a/apps/chat_server/lib/chat_server/schemas/user.ex
+++ b/apps/chat_server/lib/chat_server/schemas/user.ex
@@ -47,13 +47,6 @@ defmodule ChatServer.Schema.User do
   def get_by(params) when is_map(params), do: get_by(Enum.into(params, []))
   def get_by(params), do: Repo.get_by(User, params)
 
-  def get_or_create_by(params) do
-    case get_by(params) do
-      nil -> create(params)
-      user -> {:ok, user}
-    end
-  end
-
   # Mutations
 
   def create(params) do

--- a/apps/chat_websocket/lib/chat_websocket/channels/user_socket.ex
+++ b/apps/chat_websocket/lib/chat_websocket/channels/user_socket.ex
@@ -3,8 +3,6 @@ defmodule ChatWebsocket.UserSocket do
 
   use Phoenix.Socket
 
-  alias ChatServer.Auth
-
   ## Channels
   channel "room:*", ChatWebsocket.RoomChannel
   channel "rooms", ChatWebsocket.RoomsChannel
@@ -27,24 +25,14 @@ defmodule ChatWebsocket.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
 
-  def connect(%{"token" => token}, socket) do
-    with {:ok, auth_user} <- Auth.get_user(token),
-         {:ok, user} <- GetSocketUser.call(:user, auth_user) do
+  def connect(params, socket) do
+    with {:ok, user} <- GetSocketUser.call(params) do
       Logger.debug "Socket connection for user #{user.name} (#{user.id})"
       {:ok, assign(socket, :user, user)}
     else
       _ -> :error
     end
   end
-  def connect(%{"type" => "guest"} = params, socket) do
-    with {:ok, user} <- GetSocketUser.call(params) do
-      Logger.debug "Socket connection for guest #{user.name} (#{user.id})"
-      {:ok, assign(socket, :user, user)}
-    else
-      _ -> :error
-    end
-  end
-  def connect(_params, _socket), do: :error
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
   #


### PR DESCRIPTION
Refactors socket connection code into a context. Broadcasts a `user:created` event on the `users` topic when a user is created.